### PR TITLE
Mvx.IocConstruct<TConcrete> support improved (bugfix?)

### DIFF
--- a/src/Autofac.Extras.MvvmCross/AutoFacPropertyInjectionOptions.cs
+++ b/src/Autofac.Extras.MvvmCross/AutoFacPropertyInjectionOptions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Cirrious.CrossCore.IoC;
+
+namespace Autofac.Extras.MvvmCross
+{
+    /// <summary>
+    /// Adds some additional features to autofacpropertyinjection
+    /// </summary>
+    public interface IAutofacPropertyInjectorOptions : IMvxPropertyInjectorOptions
+    {
+        /// <summary>
+        /// An additiona attribute to use to mark a property to be injected by Property Injection
+        /// </summary>
+        Type CustomInjectorAttributeType { get; set; }
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public class AutoFacPropertyInjectionOptions : MvxPropertyInjectorOptions, IAutofacPropertyInjectorOptions
+    {
+        /// <summary>
+        /// An additiona attribute to use to mark a property to be injected by Property Injection
+        /// </summary>
+        public Type CustomInjectorAttributeType { get; set; }
+    }
+}

--- a/src/Autofac.Extras.MvvmCross/AutoFacPropertyInjectionOptions.cs
+++ b/src/Autofac.Extras.MvvmCross/AutoFacPropertyInjectionOptions.cs
@@ -1,30 +1,26 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Cirrious.CrossCore.IoC;
 
 namespace Autofac.Extras.MvvmCross
 {
     /// <summary>
-    /// Adds some additional features to autofacpropertyinjection
+    /// Autofac property injection options.
     /// </summary>
     public interface IAutofacPropertyInjectorOptions : IMvxPropertyInjectorOptions
     {
         /// <summary>
-        /// An additiona attribute to use to mark a property to be injected by Property Injection
+        /// An additional attribute used to mark a property as requiring property injection.
         /// </summary>
         Type CustomInjectorAttributeType { get; set; }
     }
 
     /// <summary>
-    /// 
+    /// Autofac property injection options.
     /// </summary>
-    public class AutoFacPropertyInjectionOptions : MvxPropertyInjectorOptions, IAutofacPropertyInjectorOptions
+    public class AutofacPropertyInjectionOptions : MvxPropertyInjectorOptions, IAutofacPropertyInjectorOptions
     {
         /// <summary>
-        /// An additiona attribute to use to mark a property to be injected by Property Injection
+        /// An additional attribute used to mark a property as requiring property injection.
         /// </summary>
         public Type CustomInjectorAttributeType { get; set; }
     }

--- a/src/Autofac.Extras.MvvmCross/Autofac.Extras.MvvmCross.csproj
+++ b/src/Autofac.Extras.MvvmCross/Autofac.Extras.MvvmCross.csproj
@@ -51,6 +51,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>AutofacMvxIocProviderResources.resx</DependentUpon>
     </Compile>
+    <Compile Include="AutoFacPropertyInjectionOptions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <CodeAnalysisDictionary Include="..\..\CodeAnalysisDictionary.xml">
       <Link>CodeAnalysisDictionary.xml</Link>

--- a/src/Autofac.Extras.MvvmCross/AutofacMvxIocProvider.cs
+++ b/src/Autofac.Extras.MvvmCross/AutofacMvxIocProvider.cs
@@ -66,7 +66,7 @@ namespace Autofac.Extras.MvvmCross
             PropertyInjectionEnabled = propertyInjectionOptions.InjectIntoProperties != MvxPropertyInjection.None;
 
             var autofacOptions = propertyInjectionOptions as IAutofacPropertyInjectorOptions;
-            if (autofacOptions != null && autofacOptions.CustomInjectorAttributeType.IsAssignableTo<Attribute>())
+            if (autofacOptions != null && autofacOptions.CustomInjectorAttributeType != null && autofacOptions.CustomInjectorAttributeType.IsAssignableTo<Attribute>())
                 _customInjectorAttributeType = autofacOptions.CustomInjectorAttributeType;
         }
 

--- a/src/Autofac.Extras.MvvmCross/AutofacMvxIocProvider.cs
+++ b/src/Autofac.Extras.MvvmCross/AutofacMvxIocProvider.cs
@@ -58,11 +58,13 @@ namespace Autofac.Extras.MvvmCross
         /// </exception>
         public AutofacMvxIocProvider(IContainer container, IMvxPropertyInjectorOptions propertyInjectionOptions)
         {
-            PropertyInjectionOptions = propertyInjectionOptions;
             if (container == null)
                 throw new ArgumentNullException("container");
+            if (propertyInjectionOptions == null) 
+                throw new ArgumentNullException("propertyInjectionOptions");
 
             _container = container;
+            PropertyInjectionOptions = propertyInjectionOptions;
             PropertyInjectionEnabled = propertyInjectionOptions.InjectIntoProperties != MvxPropertyInjection.None;
 
             var autofacOptions = propertyInjectionOptions as IAutofacPropertyInjectorOptions;
@@ -73,19 +75,21 @@ namespace Autofac.Extras.MvvmCross
         /// <summary>
         /// Initializes a new instance of the <see cref="AutofacMvxIocProvider"/> class.
         /// </summary>
-        /// <param name="container"></param>
+        /// <param name="container">
+        /// The container from which dependencies should be resolved.
+        /// </param>
         public AutofacMvxIocProvider(IContainer container)
             : this(container, new MvxPropertyInjectorOptions())
         {
         }
 
         /// <summary>
-        /// Gets/sets whether propertyinjection is enabled by default
+        /// Determines if property injection is enabled.
         /// </summary>
         public bool PropertyInjectionEnabled { get; private set; }
 
         /// <summary>
-        /// gets the propertyinjection options
+        /// Gets the property injection options.
         /// </summary>
         public IMvxPropertyInjectorOptions PropertyInjectionOptions { get; private set; }
 
@@ -544,10 +548,7 @@ namespace Autofac.Extras.MvvmCross
             }
             catch (DependencyResolutionException ex)
             {
-                // throw MvxIoCResolveException
-                if (ex.InnerException is MvxIoCResolveException)
-                    throw ex.InnerException;
-                throw;
+                throw new MvxIoCResolveException(ex, "Could not resolve {0}. See InnerException for details", type.FullName);
             }
         }
 
@@ -631,7 +632,11 @@ namespace Autofac.Extras.MvvmCross
                     {
                         if (PropertyInjectionOptions.ThrowIfPropertyInjectionFails)
                         {
-                            throw new MvxIoCResolveException(x, "Could not resolve property {0} of type {1} on {2}", property.Name, property.PropertyType.FullName, type.FullName);
+                            throw;
+                        }
+                        else
+                        {
+                            Mvx.Warning("Could not resolve property {0} of type {1} on {2}", property.Name, property.PropertyType.FullName, type.FullName);
                         }
                     }
 

--- a/src/Autofac.Extras.MvvmCross/AutofacMvxIocProvider.cs
+++ b/src/Autofac.Extras.MvvmCross/AutofacMvxIocProvider.cs
@@ -351,9 +351,7 @@ namespace Autofac.Extras.MvvmCross
                 throw new ArgumentNullException("theObject");
 
             var cb = new ContainerBuilder();
-            var x = cb.RegisterInstance(theObject).As(tInterface).AsSelf().SingleInstance();
-            if (PropertyInjectionEnabled)
-                EnablePropertyInjection(tInterface, x);
+            cb.RegisterInstance(theObject).As(tInterface).AsSelf().SingleInstance();
 
             cb.Update(_container);
         }
@@ -384,7 +382,7 @@ namespace Autofac.Extras.MvvmCross
             var type = theConstructor.GetMethodInfo().ReturnType;
             var x = cb.RegisterType(type).As(tInterface).AsSelf().SingleInstance();
             if (PropertyInjectionEnabled)
-                EnablePropertyInjection(tInterface, x);
+                EnablePropertyInjection(type, x);
 
             var y = cb.Register(cc => theConstructor()).As(tInterface).AsSelf().SingleInstance();
             if (PropertyInjectionEnabled)
@@ -436,9 +434,10 @@ namespace Autofac.Extras.MvvmCross
                 throw new ArgumentNullException("constructor");
 
             var cb = new ContainerBuilder();
+            var type = constructor.GetMethodInfo().ReturnType;
             var x = cb.Register(c => constructor()).AsSelf();
             if (PropertyInjectionEnabled)
-                EnablePropertyInjection(typeof(TInterface), x);
+                EnablePropertyInjection(type, x);
 
             cb.Update(_container);
         }
@@ -465,9 +464,10 @@ namespace Autofac.Extras.MvvmCross
                 throw new ArgumentNullException("constructor");
 
             var cb = new ContainerBuilder();
+            var type = constructor.GetMethodInfo().ReturnType;
             var x = cb.Register(c => constructor()).As(t).AsSelf();
             if (PropertyInjectionEnabled)
-                EnablePropertyInjection(t, x);
+                EnablePropertyInjection(type, x);
 
             cb.Update(_container);
         }

--- a/src/Autofac.Extras.MvvmCross/AutofacMvxIocProvider.cs
+++ b/src/Autofac.Extras.MvvmCross/AutofacMvxIocProvider.cs
@@ -48,16 +48,32 @@ namespace Autofac.Extras.MvvmCross
         /// <param name="container">
         /// The container from which dependencies should be resolved.
         /// </param>
+        /// <param name="propertyInjectionEnabled"></param>
         /// <exception cref="System.ArgumentNullException">
         /// Thrown if <paramref name="container"/> is <see langword="null"/>.
         /// </exception>
-        public AutofacMvxIocProvider(IContainer container)
+        public AutofacMvxIocProvider(IContainer container, bool propertyInjectionEnabled)
         {
             if (container == null)
                 throw new ArgumentNullException("container");
 
             _container = container;
+            PropertyInjectionEnabled = propertyInjectionEnabled;
         }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AutofacMvxIocProvider"/> class.
+        /// </summary>
+        /// <param name="container"></param>
+        public AutofacMvxIocProvider(IContainer container)
+            : this(container, false)
+        {
+        }
+
+        /// <summary>
+        /// Gets/sets whether propertyinjection is enabled by default
+        /// </summary>
+        private bool PropertyInjectionEnabled { get; set; }
 
         /// <summary>
         /// Registers an action to occur when a specific type is registered.
@@ -321,7 +337,10 @@ namespace Autofac.Extras.MvvmCross
                 throw new ArgumentNullException("theObject");
 
             var cb = new ContainerBuilder();
-            cb.RegisterInstance(theObject).As(tInterface).AsSelf().SingleInstance();
+            var x = cb.RegisterInstance(theObject).As(tInterface).AsSelf().SingleInstance();
+            if (PropertyInjectionEnabled)
+                x.PropertiesAutowired();
+
             cb.Update(_container);
         }
 
@@ -349,8 +368,15 @@ namespace Autofac.Extras.MvvmCross
             var cb = new ContainerBuilder();
 
             var type = theConstructor.GetMethodInfo().ReturnType;
-            cb.RegisterType(type).As(tInterface).AsSelf().SingleInstance();
-            cb.Register(cc => theConstructor()).As(tInterface).AsSelf().SingleInstance();
+            var x = cb.RegisterType(type).As(tInterface).AsSelf().SingleInstance();
+            if (PropertyInjectionEnabled)
+                x.PropertiesAutowired();
+
+            var y = cb.Register(cc => theConstructor()).As(tInterface).AsSelf().SingleInstance();
+            if (PropertyInjectionEnabled)
+                y.PropertiesAutowired();
+
+
             cb.Update(_container);
         }
 
@@ -396,7 +422,10 @@ namespace Autofac.Extras.MvvmCross
                 throw new ArgumentNullException("constructor");
 
             var cb = new ContainerBuilder();
-            cb.Register(c => constructor()).AsSelf();
+            var x = cb.Register(c => constructor()).AsSelf();
+            if (PropertyInjectionEnabled)
+                x.PropertiesAutowired();
+
             cb.Update(_container);
         }
 
@@ -422,7 +451,10 @@ namespace Autofac.Extras.MvvmCross
                 throw new ArgumentNullException("constructor");
 
             var cb = new ContainerBuilder();
-            cb.Register(c => constructor()).As(t).AsSelf();
+            var x = cb.Register(c => constructor()).As(t).AsSelf();
+            if (PropertyInjectionEnabled)
+                x.PropertiesAutowired();
+
             cb.Update(_container);
         }
 
@@ -454,7 +486,10 @@ namespace Autofac.Extras.MvvmCross
                 throw new ArgumentNullException("tTo");
 
             var cb = new ContainerBuilder();
-            cb.RegisterType(tTo).As(tFrom).AsSelf();
+            var x = cb.RegisterType(tTo).As(tFrom).AsSelf();
+            if (PropertyInjectionEnabled)
+                x.PropertiesAutowired();
+
             cb.Update(_container);
         }
 

--- a/src/Autofac.Extras.MvvmCross/AutofacMvxIocProvider.cs
+++ b/src/Autofac.Extras.MvvmCross/AutofacMvxIocProvider.cs
@@ -26,6 +26,7 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 using Autofac.Core;
 using Autofac.Core.Lifetime;
 using Autofac.Core.Registration;
@@ -259,6 +260,9 @@ namespace Autofac.Extras.MvvmCross
         /// </exception>
         public object IoCConstruct(Type type)
         {
+            if (!_container.IsRegistered(type))
+                RegisterType(type, type);
+
             return Resolve(type);
         }
 
@@ -343,6 +347,9 @@ namespace Autofac.Extras.MvvmCross
                 throw new ArgumentNullException("theConstructor");
 
             var cb = new ContainerBuilder();
+
+            var type = theConstructor.GetMethodInfo().ReturnType;
+            cb.RegisterType(type).As(tInterface).AsSelf().SingleInstance();
             cb.Register(cc => theConstructor()).As(tInterface).AsSelf().SingleInstance();
             cb.Update(_container);
         }

--- a/test/Autofac.Extras.Tests.MvvmCross/Autofac.Extras.Tests.MvvmCross.csproj
+++ b/test/Autofac.Extras.Tests.MvvmCross/Autofac.Extras.Tests.MvvmCross.csproj
@@ -84,6 +84,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AutofacMvxIocProviderPropertyInjectionFixture.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AutofacMvxIocProviderFixture.cs" />
   </ItemGroup>

--- a/test/Autofac.Extras.Tests.MvvmCross/AutofacMvxIocProviderFixture.cs
+++ b/test/Autofac.Extras.Tests.MvvmCross/AutofacMvxIocProviderFixture.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Configuration;
 using Autofac.Extras.MvvmCross;
 using Autofac.Core.Registration;
 using Autofac.Core;
+using Cirrious.CrossCore;
 using NUnit.Framework;
 
 namespace Autofac.Extras.Tests.MvvmCross
@@ -206,6 +208,24 @@ namespace Autofac.Extras.Tests.MvvmCross
         {
             Assert.That(() => _provider.CallbackWhenRegistered(null, () => new object()), Throws.TypeOf<ArgumentNullException>());
             Assert.That(() => _provider.CallbackWhenRegistered(typeof(object), null), Throws.TypeOf<ArgumentNullException>());
+        }
+
+        [Test]
+        public void SupportsSingletonRegistrationWithMvxIoCConstructFunc()
+        {
+            _provider.RegisterSingleton<IInterface>(Mvx.IocConstruct<Concrete>);
+
+            var concrete = _provider.Resolve<IInterface>();
+
+            Assert.IsNotNull(concrete);
+        }
+
+        [Test]
+        public void SupportsMvxIocConstructWithoutRegistration()
+        {
+            var obj = Mvx.IocConstruct<Concrete>();
+
+            Assert.IsNotNull(obj);
         }
 
         private interface IInterface

--- a/test/Autofac.Extras.Tests.MvvmCross/AutofacMvxIocProviderFixture.cs
+++ b/test/Autofac.Extras.Tests.MvvmCross/AutofacMvxIocProviderFixture.cs
@@ -4,6 +4,7 @@ using Autofac.Extras.MvvmCross;
 using Autofac.Core.Registration;
 using Autofac.Core;
 using Cirrious.CrossCore;
+using Cirrious.CrossCore.Exceptions;
 using NUnit.Framework;
 
 namespace Autofac.Extras.Tests.MvvmCross
@@ -64,8 +65,8 @@ namespace Autofac.Extras.Tests.MvvmCross
         [Test]
         public void ResolveCreateAndIoCConstructThrowsComponentNotRegisteredExceptionWhenNoTypeRegistered()
         {
-            Assert.That(() => _provider.Resolve<object>(), Throws.TypeOf<ComponentNotRegisteredException>());
-            Assert.That(() => _provider.Create<object>(), Throws.TypeOf<ComponentNotRegisteredException>());
+            Assert.That(() => _provider.Resolve<object>(), Throws.TypeOf<MvxIoCResolveException>());
+            Assert.That(() => _provider.Create<object>(), Throws.TypeOf<MvxIoCResolveException>());
         }
 
         [Test]

--- a/test/Autofac.Extras.Tests.MvvmCross/AutofacMvxIocProviderFixture.cs
+++ b/test/Autofac.Extras.Tests.MvvmCross/AutofacMvxIocProviderFixture.cs
@@ -66,7 +66,6 @@ namespace Autofac.Extras.Tests.MvvmCross
         {
             Assert.That(() => _provider.Resolve<object>(), Throws.TypeOf<ComponentNotRegisteredException>());
             Assert.That(() => _provider.Create<object>(), Throws.TypeOf<ComponentNotRegisteredException>());
-            Assert.That(() => _provider.IoCConstruct<object>(), Throws.TypeOf<ComponentNotRegisteredException>());
         }
 
         [Test]
@@ -228,12 +227,32 @@ namespace Autofac.Extras.Tests.MvvmCross
             Assert.IsNotNull(obj);
         }
 
+        [Test]
+        public void IgnoresPropertiesByDefault()
+        {
+            // Arrange
+            Mvx.RegisterType<IInterface, Concrete>();
+
+            // Act
+            var obj = Mvx.IocConstruct<HasDependantProperty>();
+
+            // Assert
+            Assert.IsNotNull(obj);
+            Assert.IsNull(obj.Dependency);
+        }
+
+
         private interface IInterface
         {
         }
 
         private class Concrete : IInterface
         {
+        }
+
+        private class HasDependantProperty
+        {
+            public IInterface Dependency { get; set; }
         }
     }
 }

--- a/test/Autofac.Extras.Tests.MvvmCross/AutofacMvxIocProviderPropertyInjectionFixture.cs
+++ b/test/Autofac.Extras.Tests.MvvmCross/AutofacMvxIocProviderPropertyInjectionFixture.cs
@@ -86,7 +86,7 @@ namespace Autofac.Extras.Tests.MvvmCross
         public void InjectsOnlyMarkedProperties_WithCustomAttribute_IfEnabled()
         {
             // Arrange
-            _provider = new AutofacMvxIocProvider(_container, new AutoFacPropertyInjectionOptions()
+            _provider = new AutofacMvxIocProvider(_container, new AutofacPropertyInjectionOptions()
             {
                 InjectIntoProperties = MvxPropertyInjection.MvxInjectInterfaceProperties,
                 CustomInjectorAttributeType = typeof(MyInjectionAttribute),
@@ -107,7 +107,7 @@ namespace Autofac.Extras.Tests.MvvmCross
         public void InjectsOnlyMarkedProperties_WithCustomAttribute_IfEnabled_Lazy()
         {
             // Arrange
-            _provider = new AutofacMvxIocProvider(_container, new AutoFacPropertyInjectionOptions()
+            _provider = new AutofacMvxIocProvider(_container, new AutofacPropertyInjectionOptions()
             {
                 InjectIntoProperties = MvxPropertyInjection.MvxInjectInterfaceProperties,
                 CustomInjectorAttributeType = typeof(MyInjectionAttribute),
@@ -164,6 +164,7 @@ namespace Autofac.Extras.Tests.MvvmCross
 
             // Assert
             Assert.IsNotNull(exception, "Exception expected");
+            Assert.IsTrue(exception.InnerException is DependencyResolutionException, "Autofac exception is not forwarded!");
         }
 
         private interface IInterface

--- a/test/Autofac.Extras.Tests.MvvmCross/AutofacMvxIocProviderPropertyInjectionFixture.cs
+++ b/test/Autofac.Extras.Tests.MvvmCross/AutofacMvxIocProviderPropertyInjectionFixture.cs
@@ -46,7 +46,6 @@ namespace Autofac.Extras.Tests.MvvmCross
             Assert.IsNotNull(obj.MarkedDependency);
         }
 
-
         [Test]
         public void InjectsOnlyMarkedPropertiesIfEnabled()
         {
@@ -57,6 +56,24 @@ namespace Autofac.Extras.Tests.MvvmCross
 
             // Act
             var obj = Mvx.IocConstruct<HasDependantProperty>();
+
+            // Assert
+            Assert.IsNotNull(obj);
+            Assert.IsNull(obj.Dependency);
+            Assert.IsNotNull(obj.MarkedDependency);
+        }
+
+        [Test]
+        public void InjectsOnlyMarkedPropertiesIfEnabled_Lazy()
+        {
+            // Arrange
+            _provider = new AutofacMvxIocProvider(_container, new MvxPropertyInjectorOptions() { InjectIntoProperties = MvxPropertyInjection.MvxInjectInterfaceProperties });
+            Mvx.RegisterType<IInterface, Concrete>();
+            Mvx.RegisterType<IInterface2, Concrete2>();
+            Mvx.RegisterSingleton<IHasDependantProperty>(Mvx.IocConstruct<HasDependantProperty>);
+
+            // Act
+            var obj = Mvx.Resolve<IHasDependantProperty>();
 
             // Assert
             Assert.IsNotNull(obj);
@@ -84,6 +101,30 @@ namespace Autofac.Extras.Tests.MvvmCross
             Assert.IsNotNull(obj.Dependency);
             Assert.IsNotNull(obj.MarkedDependency);
         }
+
+
+        [Test]
+        public void InjectsOnlyMarkedProperties_WithCustomAttribute_IfEnabled_Lazy()
+        {
+            // Arrange
+            _provider = new AutofacMvxIocProvider(_container, new AutoFacPropertyInjectionOptions()
+            {
+                InjectIntoProperties = MvxPropertyInjection.MvxInjectInterfaceProperties,
+                CustomInjectorAttributeType = typeof(MyInjectionAttribute),
+            });
+            Mvx.RegisterType<IInterface, Concrete>();
+            Mvx.RegisterType<IInterface2, Concrete2>();
+            Mvx.RegisterSingleton<IHasDependantProperty>(Mvx.IocConstruct<HasDependantProperty>);
+
+            // Act
+            var obj = Mvx.Resolve<IHasDependantProperty>();
+
+            // Assert
+            Assert.IsNotNull(obj);
+            Assert.IsNotNull(obj.Dependency);
+            Assert.IsNotNull(obj.MarkedDependency);
+        }
+
 
         [Test]
         public void IgnoresNonResolvableProperty()
@@ -147,7 +188,7 @@ namespace Autofac.Extras.Tests.MvvmCross
             
         }
 
-        private class HasDependantProperty
+        private class HasDependantProperty : IHasDependantProperty
         {
             [MyInjectionAttribute]
             public IInterface Dependency { get; set; }
@@ -155,5 +196,11 @@ namespace Autofac.Extras.Tests.MvvmCross
             [MvxInject]
             public IInterface2 MarkedDependency { get; set; }
         }
+        private interface IHasDependantProperty
+        {
+            IInterface Dependency { get; set; }
+            IInterface2 MarkedDependency { get; set; }
+        }
     }
+
 }

--- a/test/Autofac.Extras.Tests.MvvmCross/AutofacMvxIocProviderPropertyInjectionFixture.cs
+++ b/test/Autofac.Extras.Tests.MvvmCross/AutofacMvxIocProviderPropertyInjectionFixture.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Configuration;
+using Autofac.Extras.MvvmCross;
+using Autofac.Core.Registration;
+using Autofac.Core;
+using Cirrious.CrossCore;
+using NUnit.Framework;
+
+namespace Autofac.Extras.Tests.MvvmCross
+{
+    [TestFixture]
+    public class AutofacMvxIocProviderPropertyInjectionFixture
+    {
+        IContainer _container;
+        AutofacMvxIocProvider _provider;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _container = new ContainerBuilder().Build();
+            _provider = new AutofacMvxIocProvider(_container, true);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _provider.Dispose();
+        }
+
+
+        [Test]
+        public void InjectsPropertiesIfEnabled()
+        {
+            // Arrange
+            Mvx.RegisterType<IInterface, Concrete>();
+            
+            // Act
+            var obj = Mvx.IocConstruct<HasDependantProperty>();
+            
+            // Assert
+            Assert.IsNotNull(obj);
+            Assert.IsNotNull(obj.Dependency);
+        }
+
+        private interface IInterface
+        {
+        }
+
+        private class Concrete : IInterface
+        {
+        }
+
+        private class HasDependantProperty
+        {
+            public IInterface Dependency { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Fixed two issues that hindered us using this Autofac adapter:

Added support for direct `Mvx.IocConstruct<TConcrete>` without TConcrete being registered;
e.g. You were not able to call `Mvx.IocConstruct<MyRepository>()` without having called `Mvx.RegisterType<MyRepository, MyRepository>()` first

Added support for pattern `Mvx.RegisterSingleton<Tinterface>(Mvx.IocConstruct<TConcrete>)` where TConcrete is implicitly registered now;
It was not possible to write e.g.:
`Mvx.RegisterSingleton<IMyRepository>(Mvx.IocConstruct<MyRepository>);`
as again MyRepository was not registered before. I consider that a bug ;-)

Added test coverage - so it should be fine
